### PR TITLE
修正多网卡无法正确匹配IP地址bug,多网卡请指定--device

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,29 @@
+pkgname='zdcclient'
+pkgver='1.6'
+pkgrel=1
+pkgdesc="Nettool for school in china,Connect x802.1fixed"
+url="git+https://github.com/isombyt/zdcclient.git"
+arch=('x86_64' 'i386')
+license=('GPL')
+source=($pkgname::git://github.com/acoret/zdcclient.git)
+gitsource=($pkgname::https://github.com/acoret/zdcclient.git)
+makedepends=('libcap' 'make' 'git')
+depends=('libcap')
+
+md5sums=('SKIP')
+build()
+{
+  cd $pkgname
+  make -j
+}
+package()
+{
+  echo 'please edit runzdclient...'
+  cd $pkgname
+  install -Dm4755 zdclient ${pkgdir}/usr/local/bin/zdclient
+  install -Dm0755 runzdclient ${pkgdir}/usr/local/bin/runzdclient
+}
+post_install()
+{
+  echo 'please check if /usr/local/bin/runzdclient contain right user and passwd'
+}

--- a/main.c
+++ b/main.c
@@ -104,6 +104,8 @@ program_running_check()
             if ( kill (fl.l_pid, SIGINT) == -1 )
                 perror("kill");
             fprintf (stdout, "&&Info: Kill Signal Sent to PID %d.\n", fl.l_pid);
+			if (!remove(LOCKFILE))
+			  fprintf(stdout,"&&Info: LOCKFILE delete failed,please remove it: %s",LOCKFILE);
         }
         else 
             fprintf (stderr, "&&Info: NO ZDClient Running.\n");

--- a/zdclient.c
+++ b/zdclient.c
@@ -601,6 +601,13 @@ void init_device()
         dev = alldevs->name;
         strcpy (dev_if_name, dev);
     }
+	else
+	  for(alldevs;alldevs;alldevs=alldevs->next)
+		if (strcmp(alldevs->name,dev)==0)
+		{
+	        strcpy (dev_if_name, dev);
+			break;
+		}
 
 	if (dev == NULL) {
 		fprintf(stderr, "Couldn't find default device: %s\n",
@@ -629,6 +636,9 @@ void init_device()
             local_mask = ((struct sockaddr_in *)addrs->netmask)->sin_addr.s_addr;
         }
     }
+
+	
+
 #ifdef __linux
     /* get device basic infomation */
     struct ifreq ifr;

--- a/zdclient.h
+++ b/zdclient.h
@@ -47,7 +47,7 @@
 #include "md5.h"
 
 /* ZDClient Version */
-#define ZDC_VER "0.14"
+#define ZDC_VER "0.16"
 
 /* default snap length (maximum bytes per packet to capture) */
 #define SNAP_LEN 1518

--- a/zdclient.h
+++ b/zdclient.h
@@ -47,7 +47,7 @@
 #include "md5.h"
 
 /* ZDClient Version */
-#define ZDC_VER "0.13"
+#define ZDC_VER "0.14"
 
 /* default snap length (maximum bytes per packet to capture) */
 #define SNAP_LEN 1518


### PR DESCRIPTION
当出现多个网卡的时候,比如你的无线也开着或者开着热点,就可能出现你试图用wlan0无线网卡的IP以及MAC地址向你eth0本地网卡发送登录数据,这样是无法登录的.加了个for if判断循环使IP地址变正确.